### PR TITLE
fix: Set tmpdir as a cwd for SPIN Debugger Process to avoid readonly file-system.

### DIFF
--- a/src/mockDebug.ts
+++ b/src/mockDebug.ts
@@ -12,6 +12,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 import { basename } from 'path';
 import { MockRuntime, MockBreakpoint } from './mockRuntime';
 import { spawn, ChildProcess } from 'child_process';
+import { tmpdir } from 'os';
 
 
 /**
@@ -120,7 +121,7 @@ class MockDebugSession extends LoggingDebugSession {
 
 		const spinArgs = ['-p', '-s', '-r', '-X', '-v', `-n${args.seed || 123}`, '-l', '-g', `-u${args.stepLimit || 500}`, args.program]
 		const spin = args.spin || 'spin';
-		this._spinProcess = spawn(spin, spinArgs)
+		this._spinProcess = spawn(spin, spinArgs, {cwd: tmpdir()})
 
 		this.sendEvent(new OutputEvent(`${spin} ${spinArgs.join(' ')}\n`, 'info'));
 


### PR DESCRIPTION
Without cwd option, SPIN process exited with status 1 with error:

```
stderr: sh: pan.pre: Read-only file system
stdout: spin: preprocessing failed gcc -std=gnu99 -E -x c "/Users/pocket7878/spin-example/main.pml" > "pan.pre"
```

Environment:

```
code --version
1.48.2
a0479759d6e9ea56afa657e454193f72aef85bd0
x64
```

```
spin -V
Spin Version 6.5.2 -- 6 December 2019
```